### PR TITLE
fix(sdlc): security fixes

### DIFF
--- a/app/api/admin/integrations/test/route.ts
+++ b/app/api/admin/integrations/test/route.ts
@@ -13,6 +13,52 @@ interface TestIntegrationBody {
   credentials: Record<string, string>
 }
 
+function isPrivateOrLocalHost(hostname: string): boolean {
+  const host = hostname.toLowerCase()
+
+  if (host === 'localhost' || host === '::1' || host === '[::1]') return true
+  if (host.endsWith('.localhost') || host.endsWith('.local')) return true
+
+  // IPv4 checks
+  const ipv4Match = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  if (ipv4Match) {
+    const octets = ipv4Match.slice(1).map((n) => Number(n))
+    if (octets.some((o) => Number.isNaN(o) || o < 0 || o > 255)) return true
+
+    const [a, b] = octets
+    if (a === 10) return true
+    if (a === 127) return true
+    if (a === 169 && b === 254) return true
+    if (a === 172 && b >= 16 && b <= 31) return true
+    if (a === 192 && b === 168) return true
+    if (a === 0) return true
+  }
+
+  // Common IPv6 local/private forms
+  const normalized = host.replace(/^\[|\]$/g, '')
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true // ULA
+  if (normalized.startsWith('fe80:')) return true // link-local
+
+  return false
+}
+
+function getSafeKenerOrigin(baseUrl?: string): string | null {
+  const candidate = (baseUrl && baseUrl.trim()) || 'https://emberlystat.us'
+
+  let parsed: URL
+  try {
+    parsed = new URL(candidate)
+  } catch {
+    return null
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+  if (parsed.username || parsed.password) return null
+  if (isPrivateOrLocalHost(parsed.hostname)) return null
+
+  return parsed.origin
+}
+
 interface TestResult {
   ok: boolean
   message: string
@@ -122,9 +168,13 @@ async function testGitHub(pat: string, org?: string): Promise<TestResult> {
 }
 
 async function testKener(apiKey: string, baseUrl?: string): Promise<TestResult> {
-  const url = (baseUrl || 'https://emberlystat.us').replace(/\/$/, '')
+  const origin = getSafeKenerOrigin(baseUrl)
+  if (!origin) {
+    return { ok: false, message: 'Invalid Kener base URL' }
+  }
+
   try {
-    const res = await fetch(`${url}/api/v4/monitors`, {
+    const res = await fetch(`${origin}/api/v4/monitors`, {
       headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
       signal: AbortSignal.timeout(8000),
     })

--- a/packages/lib/vultr/index.ts
+++ b/packages/lib/vultr/index.ts
@@ -16,6 +16,17 @@ import { getIntegrations } from '@/packages/lib/config'
 
 const VULTR_API_BASE = 'https://api.vultr.com/v2'
 
+function buildVultrApiUrl(path: string): string {
+    if (!path.startsWith('/')) {
+        throw new Error(`Invalid Vultr API path: "${path}"`)
+    }
+    if (path.startsWith('//') || path.includes('..') || path.includes('://')) {
+        throw new Error(`Unsafe Vultr API path: "${path}"`)
+    }
+
+    return new URL(path, VULTR_API_BASE).toString()
+}
+
 async function getApiKey(): Promise<string> {
     const integrations = await getIntegrations()
     const key = integrations?.vultr?.apiKey || process.env.VULTR_API_KEY
@@ -28,7 +39,7 @@ async function vultrRequest<T>(
     path: string,
     body?: unknown,
 ): Promise<T> {
-    const response = await fetch(`${VULTR_API_BASE}${path}`, {
+    const response = await fetch(buildVultrApiUrl(path), {
         method,
         headers: {
             Authorization: `Bearer ${await getApiKey()}`,
@@ -187,6 +198,10 @@ export async function listClusters(): Promise<VultrCluster[]> {
 
 /** List tiers available for a specific cluster. */
 export async function listClusterTiers(clusterId: number): Promise<VultrTier[]> {
+    if (!Number.isInteger(clusterId)) {
+        throw new Error(`Invalid clusterId: ${clusterId}`)
+    }
+
     const data = await vultrRequest<{ tiers: VultrTier[] }>('GET', `/object-storage/clusters/${clusterId}/tiers`)
     return data.tiers ?? []
 }


### PR DESCRIPTION
Potential fix for [https://github.com/EmberlyOSS/Emberly/security/code-scanning/13](https://github.com/EmberlyOSS/Emberly/security/code-scanning/13)

General fix: enforce strict validation/sanitization of request paths before constructing outbound URLs. Keep base host fixed and allow only API-relative paths that cannot alter scheme/host or use traversal.

Best fix here (without changing functionality): in `packages/lib/vultr/index.ts`, add a small helper that validates `path`:
- must start with `/`
- must not start with `//`
- must not contain `..`
- must not contain `://`
Then build the final URL with `new URL(safePath, VULTR_API_BASE)` and use that in `fetch`.  
Also tighten `listClusterTiers` by requiring an integer `clusterId` before interpolation.

This keeps existing behavior for valid paths, blocks malformed/dangerous ones, and satisfies SSRF hardening at the sink.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent integration testing from contacting private or local networks
  * Enhanced API request validation with improved path sanitization for third-party service integrations
  * Added parameter validation to catch invalid requests before processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->