### PR TITLE
Potential fix for code scanning alert no. 18: Server-side request forgery

### DIFF
--- a/app/api/admin/integrations/test/route.ts
+++ b/app/api/admin/integrations/test/route.ts
@@ -56,6 +56,9 @@ function getSafeKenerOrigin(baseUrl?: string): string | null {
   if (parsed.username || parsed.password) return null
   if (isPrivateOrLocalHost(parsed.hostname)) return null
 
+  const allowedOrigins = new Set(['https://emberlystat.us'])
+  if (!allowedOrigins.has(parsed.origin)) return null
+
   return parsed.origin
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/EmberlyOSS/Emberly/security/code-scanning/18](https://github.com/EmberlyOSS/Emberly/security/code-scanning/18)

Best fix: stop accepting arbitrary `baseUrl` for outbound requests and only allow known-safe Kener origins controlled by the server.

In this file, the safest minimal change is to harden `getSafeKenerOrigin` so it only returns an origin if it matches a strict allowlist (for example the default hosted instance), and otherwise returns `null`. This preserves existing behavior for the known default while preventing SSRF via arbitrary public hosts.

Changes needed in `app/api/admin/integrations/test/route.ts`:
- In `getSafeKenerOrigin`, after URL parsing and existing checks, enforce origin allowlisting.
- Add a local constant allowlist in the function (no new imports/dependencies required).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
