### PR TITLE
Potential fix for code scanning alert no. 17: Server-side request forgery

### DIFF
--- a/packages/lib/vultr/index.ts
+++ b/packages/lib/vultr/index.ts
@@ -218,11 +218,19 @@ export async function listClusters(): Promise<VultrCluster[]> {
 
 /** List tiers available for a specific cluster. */
 export async function listClusterTiers(clusterId: number): Promise<VultrTier[]> {
-    if (!Number.isInteger(clusterId)) {
+    if (!Number.isFinite(clusterId) || !Number.isSafeInteger(clusterId)) {
         throw new Error(`Invalid clusterId: ${clusterId}`)
     }
 
-    const data = await vultrRequest<{ tiers: VultrTier[] }>('GET', `/object-storage/clusters/${clusterId}/tiers`)
+    const safeClusterId = Math.trunc(clusterId)
+    if (safeClusterId !== clusterId || safeClusterId < 0) {
+        throw new Error(`Invalid clusterId: ${clusterId}`)
+    }
+
+    const data = await vultrRequest<{ tiers: VultrTier[] }>(
+        'GET',
+        `/object-storage/clusters/${safeClusterId}/tiers`
+    )
     return data.tiers ?? []
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/EmberlyOSS/Emberly/security/code-scanning/17](https://github.com/EmberlyOSS/Emberly/security/code-scanning/17)

General fix approach: ensure untrusted input cannot directly influence URL construction by canonicalizing and validating it before interpolation, and by building URLs from fixed path segments where possible.

Best targeted fix (without changing functionality): in `packages/lib/vultr/index.ts`, harden `listClusterTiers` by converting `clusterId` into a strict, canonical safe integer (`safeClusterId`) and using that canonical value for URL path construction. This keeps the same behavior for valid inputs while giving CodeQL a clearer sanitization boundary and reducing residual URL-manipulation risk.

Change region:
- `packages/lib/vultr/index.ts` around `listClusterTiers(...)` (lines ~220–226 in your snippet).

Needed implementation details:
- Add explicit finite-safe-integer checks.
- Normalize via `Math.trunc(clusterId)` and require equality to original value.
- Enforce non-negative (or positive if desired; below keeps `0` technically valid unless Vultr rejects it).
- Use `safeClusterId` in the template literal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
