### PR TITLE
Potential fix for code scanning alert no. 16: Shell command built from environment values

### DIFF
--- a/scripts/generate-media-kit.ts
+++ b/scripts/generate-media-kit.ts
@@ -16,10 +16,10 @@
 import { mkdir, writeFile, copyFile, readFile, readdir } from 'fs/promises'
 import { existsSync } from 'fs'
 import { join } from 'path'
-import { exec } from 'child_process'
+import { execFile } from 'child_process'
 import { promisify } from 'util'
 
-const execAsync = promisify(exec)
+const execFileAsync = promisify(execFile)
 
 const ROOT_DIR = process.cwd()
 const PUBLIC_DIR = join(ROOT_DIR, 'public')
@@ -440,10 +440,19 @@ async function createZip() {
   try {
     if (process.platform === 'win32') {
       // PowerShell Compress-Archive
-      await execAsync(`powershell -Command "Compress-Archive -Path '${OUTPUT_DIR}\\*' -DestinationPath '${OUTPUT_ZIP}' -Force"`)
+      await execFileAsync('powershell', [
+        '-NoProfile',
+        '-Command',
+        'Compress-Archive',
+        '-Path',
+        `${OUTPUT_DIR}\\*`,
+        '-DestinationPath',
+        OUTPUT_ZIP,
+        '-Force',
+      ])
     } else {
       // Unix zip
-      await execAsync(`cd "${OUTPUT_DIR}" && zip -r "${OUTPUT_ZIP}" .`)
+      await execFileAsync('zip', ['-r', OUTPUT_ZIP, '.'], { cwd: OUTPUT_DIR })
     }
     console.log(`✓ Created zip: ${OUTPUT_ZIP}`)
   } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/EmberlyOSS/Emberly/security/code-scanning/16](https://github.com/EmberlyOSS/Emberly/security/code-scanning/16)

The best fix is to stop using `exec` with a single shell command string and instead use `execFile` (or `spawn`) with an argument array, so paths are passed as literal arguments and not shell-interpreted.

In `scripts/generate-media-kit.ts`:
- Replace `exec` import with `execFile`.
- Replace `const execAsync = promisify(exec)` with `const execFileAsync = promisify(execFile)`.
- In `createZip()`:
  - Windows: call `powershell` via `execFileAsync('powershell', ['-NoProfile', '-Command', 'Compress-Archive', '-Path', `${OUTPUT_DIR}\\*`, '-DestinationPath', OUTPUT_ZIP, '-Force'])`.
  - Unix: avoid `cd ... && zip ...`; call `zip` directly with working directory option: `execFileAsync('zip', ['-r', OUTPUT_ZIP, '.'], { cwd: OUTPUT_DIR })`.

This preserves functionality while eliminating shell parsing of dynamic paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the media kit generation script's approach to invoking external system commands for better reliability and cross-platform compatibility on Windows and Unix-based systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->