### PR TITLE
Potential fix for code scanning alert no. 5: Replacement of a substring with itself

### DIFF
--- a/packages/lib/auth/login-detection.ts
+++ b/packages/lib/auth/login-detection.ts
@@ -44,7 +44,6 @@ export function createDeviceFingerprint(userAgent: string | null | undefined): s
         .replace(/mac os x [\d_]+/g, 'macos')
         .replace(/android [\d.]+/g, 'android')
         .replace(/iphone os [\d_]+/g, 'ios')
-        .replace(/linux/g, 'linux')
         // Extract browser
         .replace(/chrome\/[\d.]+/g, 'chrome')
         .replace(/firefox\/[\d.]+/g, 'firefox')


### PR DESCRIPTION
Potential fix for [https://github.com/EmberlyOSS/Emberly/security/code-scanning/5](https://github.com/EmberlyOSS/Emberly/security/code-scanning/5)

General fix: remove or correct any replacement where the replacement string is identical to the matched substring unless there is a deliberate reason and comment. In normalization code, each replacement should either meaningfully transform data or be omitted.

Best fix here (without changing functionality): delete the no-op `.replace(/linux/g, 'linux')` from `createDeviceFingerprint` in `packages/lib/auth/login-detection.ts`. This preserves behavior exactly while resolving the CodeQL finding and reducing confusion.

Changes needed:
- File: `packages/lib/auth/login-detection.ts`
- Region: normalization chain in `createDeviceFingerprint` (around line 47)
- No new imports, methods, or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
