### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete URL substring sanitization

### DIFF
--- a/app/api/discovery/signals/[id]/route.ts
+++ b/app/api/discovery/signals/[id]/route.ts
@@ -8,7 +8,9 @@ import { prisma } from '@/packages/lib/database/prisma'
 function parseGitHubUrl(url: string): { owner: string; repo: string } | null {
   try {
     const parsed = new URL(url)
-    if (!parsed.hostname.endsWith('github.com')) return null
+    const hostname = parsed.hostname.toLowerCase().replace(/\.$/, '')
+    const allowedHosts = new Set(['github.com', 'www.github.com'])
+    if (!allowedHosts.has(hostname)) return null
     const parts = parsed.pathname.replace(/^\//, '').split('/')
     if (parts.length < 2) return null
     return { owner: parts[0], repo: parts[1].replace(/\.git$/, '') }


### PR DESCRIPTION
Potential fix for [https://github.com/EmberlyOSS/Emberly/security/code-scanning/6](https://github.com/EmberlyOSS/Emberly/security/code-scanning/6)

The fix is to validate the parsed host against an explicit allowlist (or exact host equality), instead of substring/suffix checks. For GitHub repo URLs, the safest no-functional-change approach is to allow exactly `github.com` and `www.github.com` (if desired), and reject everything else.

In `app/api/discovery/signals/[id]/route.ts`, update `parseGitHubUrl`:

- Replace `parsed.hostname.endsWith('github.com')` with normalized exact host matching.
- Normalize by lowercasing and stripping a trailing dot to avoid edge-case bypasses (`github.com.`).
- Keep the existing path parsing behavior unchanged.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
