### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/app/api/discovery/signals/route.ts
+++ b/app/api/discovery/signals/route.ts
@@ -12,7 +12,8 @@ import {
 function parseGitHubUrl(url: string): { owner: string; repo: string } | null {
   try {
     const parsed = new URL(url)
-    if (!parsed.hostname.endsWith('github.com')) return null
+    const host = parsed.hostname.toLowerCase()
+    if (host !== 'github.com' && !host.endsWith('.github.com')) return null
     const parts = parsed.pathname.replace(/^\//, '').split('/')
     if (parts.length < 2) return null
     return { owner: parts[0], repo: parts[1].replace(/\.git$/, '') }


### PR DESCRIPTION
Potential fix for [https://github.com/EmberlyOSS/Emberly/security/code-scanning/7](https://github.com/EmberlyOSS/Emberly/security/code-scanning/7)

To fix this safely without changing intended behavior, validate the parsed hostname using exact-match or proper subdomain-boundary logic instead of raw suffix matching.

Best fix in this file:
- In `parseGitHubUrl` (around line 15), replace:
  - `parsed.hostname.endsWith('github.com')`
- With:
  - `const host = parsed.hostname.toLowerCase()`
  - allow only `host === 'github.com'` or `host.endsWith('.github.com')`

This preserves support for `github.com` and legitimate subdomains (if desired), while blocking `evilgithub.com` because it does not have a `.` boundary before `github.com`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
