### PR TITLE
Potential fix for code scanning alert no. 10: Server-side request forgery

### DIFF
--- a/app/api/admin/integrations/test/route.ts
+++ b/app/api/admin/integrations/test/route.ts
@@ -135,7 +135,20 @@ async function testDiscord(webhookUrl: string, botToken?: string, serverId?: str
   // Fall back to webhook validation
   if (webhookUrl) {
     try {
-      const res = await fetch(webhookUrl, { method: 'GET' })
+      let parsed: URL
+      try {
+        parsed = new URL(webhookUrl)
+      } catch {
+        return { ok: false, message: 'Invalid webhook URL format' }
+      }
+
+      const hostname = parsed.hostname.toLowerCase()
+      const isDiscordHost = hostname === 'discord.com' || hostname === 'discordapp.com'
+      if (parsed.protocol !== 'https:' || !isDiscordHost || isPrivateOrLocalHost(hostname)) {
+        return { ok: false, message: 'Webhook URL must be a valid Discord HTTPS URL' }
+      }
+
+      const res = await fetch(parsed.toString(), { method: 'GET' })
       if (res.status === 401) return { ok: false, message: 'Invalid webhook URL' }
       if (!res.ok) return { ok: false, message: `Discord webhook error (${res.status})` }
       return { ok: true, message: 'Discord webhook is valid' }


### PR DESCRIPTION
Potential fix for [https://github.com/EmberlyOSS/Emberly/security/code-scanning/10](https://github.com/EmberlyOSS/Emberly/security/code-scanning/10)

General fix: never call `fetch` with a raw user-provided URL. Parse and validate it first, enforce expected protocol/host allowlist, and block localhost/private/internal hosts.

Best fix here (without changing intended functionality): in `testDiscord`, before fetching `webhookUrl`, parse with `new URL(...)`, require `https:`, require host `discord.com` (and optionally `discordapp.com` legacy), and reject private/local hosts using existing `isPrivateOrLocalHost`. Then fetch using the normalized URL string.

Change scope: `app/api/admin/integrations/test/route.ts`, specifically the webhook validation block inside `testDiscord` around lines 136–144. No new dependency is required, and no import changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
