### PR TITLE
Potential fix for code scanning alert no. 19: Server-side request forgery

### DIFF
--- a/app/api/admin/integrations/test/route.ts
+++ b/app/api/admin/integrations/test/route.ts
@@ -148,7 +148,15 @@ async function testDiscord(webhookUrl: string, botToken?: string, serverId?: str
         return { ok: false, message: 'Webhook URL must be a valid Discord HTTPS URL' }
       }
 
-      const res = await fetch(parsed.toString(), { method: 'GET' })
+      const match = parsed.pathname.match(/^\/api\/webhooks\/(\d+)\/([A-Za-z0-9._-]+)$/)
+      if (!match) {
+        return { ok: false, message: 'Webhook URL must match Discord webhook format' }
+      }
+
+      const [, webhookId, webhookToken] = match
+      const safeWebhookUrl = `https://${hostname}/api/webhooks/${webhookId}/${webhookToken}`
+
+      const res = await fetch(safeWebhookUrl, { method: 'GET' })
       if (res.status === 401) return { ok: false, message: 'Invalid webhook URL' }
       if (!res.ok) return { ok: false, message: `Discord webhook error (${res.status})` }
       return { ok: true, message: 'Discord webhook is valid' }


### PR DESCRIPTION
Potential fix for [https://github.com/EmberlyOSS/Emberly/security/code-scanning/19](https://github.com/EmberlyOSS/Emberly/security/code-scanning/19)

The best fix is to **avoid fetching arbitrary user-provided URL strings**, even after basic host checks, and instead enforce a **strict Discord webhook URL allowlist pattern** and rebuild the outbound URL from validated components.

In `app/api/admin/integrations/test/route.ts`, update the webhook branch in `testDiscord` (around lines 136–152):

1. Keep URL parsing.
2. Restrict protocol to `https`.
3. Restrict hostname to exact allowed values.
4. Add strict path validation for Discord webhook format:  
   `/api/webhooks/{webhookId}/{webhookToken}` where:
   - `webhookId` is digits only
   - `webhookToken` is safe URL token chars only
5. Reconstruct a normalized URL from validated `hostname` + extracted path segments.
6. Use that reconstructed URL in `fetch`, not `parsed.toString()`.

No new dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
